### PR TITLE
Support Vite 5 in `peerDependences`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "vite-plugin-inspect": "^0.7.15"
   },
   "peerDependencies": {
-    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This plugin continues to work as expected with Vite 5. This change merely adds the `5.0.0` version range to the acceptable versions in `peerDependencies`.